### PR TITLE
Fix for blank assignee on status descriptions

### DIFF
--- a/server/ideas-server/ideas-server/Models/InitiativeStepDetail.cs
+++ b/server/ideas-server/ideas-server/Models/InitiativeStepDetail.cs
@@ -54,7 +54,11 @@ namespace CoE.Ideas.Server.Models
                         Person assignee = null;
                         if (step.PersonId.HasValue)
                             assignee = await personRepository.GetPersonAsync(step.PersonId.Value);
-                        stepDto.Description = string.Format(textTemplate, assignee?.Name, expectedCompletionDateString);
+
+                        string assigneeName = assignee?.Name;
+                        if (string.IsNullOrWhiteSpace(assigneeName))
+                            assigneeName = "An OCT representative";
+                        stepDto.Description = string.Format(textTemplate, assigneeName, expectedCompletionDateString);
                     }
                 }
 


### PR DESCRIPTION
I noticed that the default text of "An OCT representative" was not showing in the status descriptions when no BA is assigned to the Work Order in Remedy.

This is a fix for that.
