### PR TITLE
lowercased wordpress db name

### DIFF
--- a/ideas-integration-apex/appsettings.json
+++ b/ideas-integration-apex/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "ConnectionStrings": {
     "IdeaDatabase": "server=initiatives-db;uid=SA;pwd=OctavaDev100!;database=CoeIdeas",
-    "WordPressDatabase": "server=wordpress-db;uid=root;pwd=octavadev;database=OctPortalWordPress",
+    "WordPressDatabase": "server=wordpress-db;uid=root;pwd=octavadev;database=octportalwordpress",
     "ServiceBusEmulator": "server=initiatives-db;uid=SA;pwd= OctavaDev100!;database=ServiceBusEmulator"
   }
 }

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: octavadev
-      MYSQL_DATABASE: OctPortalWordPress
+      MYSQL_DATABASE: octportalwordpress
 
 
   initiatives-db:
@@ -40,7 +40,7 @@ services:
     restart: always
     environment:
       WORDPRESS_DB_HOST: wordpress-db:3306
-      WORDPRESS_DB_NAME: OctPortalWordPress
+      WORDPRESS_DB_NAME: octportalwordpress
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: octavadev
 

--- a/server/shared-kernel/Extensions/ServiceCollectionExtensions.cs
+++ b/server/shared-kernel/Extensions/ServiceCollectionExtensions.cs
@@ -20,7 +20,7 @@ namespace CoE.Ideas.Shared.Extensions
         {
             // defaults (for dev environment) - this is not the same as Production!!
             string connectionString = string.IsNullOrWhiteSpace(wordPressDbConnectionString)
-                ? "server=wordpress-db;uid=root;pwd=octavadev;database=OctPortalWordPress"
+                ? "server=wordpress-db;uid=root;pwd=octavadev;database=octportalwordpress"
                 : wordPressDbConnectionString;
 
             services.AddDbContext<WordPressContext>(options =>
@@ -93,7 +93,7 @@ namespace CoE.Ideas.Shared.Extensions
         {
             // defaults (for dev environment) - this is not the same as Production!!
             string connectionString = string.IsNullOrWhiteSpace(permissionDbConnectionString)
-                ? "server=wordpress-db;uid=root;pwd=octavadev;database=OctPortalWordPress"
+                ? "server=wordpress-db;uid=root;pwd=octavadev;database=octportalwordpress"
                 : permissionDbConnectionString;
 
             services.AddDbContext<SecurityContext>(options =>


### PR DESCRIPTION
Visual Studio docker-compose stopped loading the database.  We've needed to lowercase the "octportalwordpress" for some time, can't remember exactly when this started.  It was when we started loading the db with production backups on container startup